### PR TITLE
Add PHPUnit test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 ## [Unreleased]
 
 ## [3.0.0] - 2026-07-13
+### Added
+- Added a PHPUnit test suite (Unit/Kernel/Functional) covering the Utility/Name helpers and the Zendesk webform handler
+- Added `config/schema/zendesk_webform.schema.yml`, providing config schema for the admin settings and the handler's settings (previously missing, which strict config validation flagged)
+- Added a ddev local development environment (via `ddev/ddev-drupal-contrib`) for ongoing module development
+
 ### Changed
 - Modernized for Drupal 10/11: `core_version_requirement: ^10 || ^11`, PHP `>=8.1`
 - Updated `zendesk/zendesk_api_client_php` dependency to `^4.1` (from `^2.2.11`)
 - Updated `webform` dependency constraint to `>=6.2`
 - Removed the committed `composer.lock` (not meaningful for a library-type package)
-- Added a ddev local development environment (via `ddev/ddev-drupal-contrib`) for ongoing module development
+- Extracted the Zendesk ticket request-building logic out of `ZendeskHandler::postSave()` into a new `buildTicketRequest()` method, so it can be tested independently of the live API call
 
 ### Fixed
 - Removed an invalid `#theme: markup` key from the handler summary render array, which logged a spurious "Theme hook markup not found" warning on every Handlers listing page view

--- a/config/schema/zendesk_webform.schema.yml
+++ b/config/schema/zendesk_webform.schema.yml
@@ -1,0 +1,57 @@
+zendesk_webform.adminsettings:
+  type: config_object
+  label: 'Zendesk Integration settings'
+  mapping:
+    subdomain:
+      type: string
+      label: 'Zendesk subdomain'
+    user_email:
+      type: email
+      label: 'Zendesk account email address'
+    web_token:
+      type: string
+      label: 'Zendesk API token'
+
+webform.handler.zendesk:
+  type: mapping
+  label: 'Zendesk'
+  mapping:
+    requester_name:
+      type: string
+      label: 'Requester name'
+    requester_email:
+      type: string
+      label: 'Requester email address'
+    subject:
+      type: label
+      label: 'Subject'
+    comment:
+      type: text
+      label: 'Ticket body'
+    tags:
+      type: string
+      label: 'Ticket tags'
+    priority:
+      type: string
+      label: 'Ticket priority'
+    status:
+      type: string
+      label: 'Ticket status'
+    assignee_id:
+      type: string
+      label: 'Ticket assignee'
+    type:
+      type: string
+      label: 'Ticket type'
+    collaborators:
+      type: string
+      label: 'Ticket CCs'
+    custom_fields:
+      type: text
+      label: 'Ticket custom fields'
+    ticket_id_field:
+      type: string
+      label: 'Zendesk ticket ID field'
+    delete_after_delivery:
+      type: boolean
+      label: 'Enable record deletion after delivery'

--- a/src/Plugin/WebformHandler/ZendeskHandler.php
+++ b/src/Plugin/WebformHandler/ZendeskHandler.php
@@ -467,59 +467,9 @@ class ZendeskHandler extends WebformHandlerBase
         // run only for new submissions
         if (! $update) {
 
-            // declare working variables
-            $request = [];
             $submission_fields = $webform_submission->toArray(TRUE);
             $configuration = $this->getTokenManager()->replace($this->configuration, $webform_submission);
-
-            // Allow for either values coming from other fields or static/tokens
-            foreach ($this->defaultConfigurationNames() as $field) {
-                $request[$field] = $configuration[$field];
-                if (!empty($submission_fields['data'][$configuration[$field]])) {
-                    $request[$field] = $submission_fields['data'][$configuration[$field]];
-                }
-            }
-
-            // clean up tags
-            $request['tags'] = Utility::cleanTags( $request['tags'] );
-            $request['collaborators'] = preg_split("/[^a-z0-9_\-@\.']+/i", $request['collaborators'] );
-
-            // restructure requester
-            if(!isset($request['requester'])){
-                $request['requester'] = $request['requester_name']
-                    ? [
-                        'name' => Utility::convertName($request['requester_name']),
-                        'email' => $request['requester_email'],
-                    ]
-                    : $request['requester_email'];
-
-                unset($request['requester_name']);
-                unset($request['requester_email']);
-            }
-
-            // restructure comment array
-            if(!isset($request['comment']['body'])){
-                $comment = $request['comment'];
-                $request['comment'] = [
-                    'body' => $comment
-                ];
-            }
-
-            // convert custom fields format from [key:data} to [id:key,value:data] for Zendesk field referencing
-            $custom_fields = Yaml::decode($request['custom_fields']);
-            unset($request['custom_fields']);
-            $request['custom_fields'] = [];
-            if($custom_fields) {
-                foreach ($custom_fields as $key => $value) {
-                    $request['custom_fields'][] = [
-                        'id' => $key,
-                        'value' => $value
-                    ];
-                }
-            }
-
-            // set external_id to connect zendesk ticket with submission ID
-            $request['external_id'] = $webform_submission->id();
+            $request = $this->buildTicketRequest($configuration, $submission_fields, $webform_submission);
 
             // get list of all webform fields with a file field type
             $file_fields = $this->getWebformFieldsWithFiles();
@@ -607,6 +557,69 @@ class ZendeskHandler extends WebformHandlerBase
             }
         }
         return;
+    }
+
+    /**
+     * Builds the Zendesk ticket creation request from handler configuration and submission data.
+     * @param array $configuration
+     * @param array $submission_fields
+     * @param WebformSubmissionInterface $webform_submission
+     * @return array
+     */
+    protected function buildTicketRequest(array $configuration, array $submission_fields, WebformSubmissionInterface $webform_submission)
+    {
+        $request = [];
+
+        // Allow for either values coming from other fields or static/tokens
+        foreach ($this->defaultConfigurationNames() as $field) {
+            $request[$field] = $configuration[$field];
+            if (!empty($submission_fields['data'][$configuration[$field]])) {
+                $request[$field] = $submission_fields['data'][$configuration[$field]];
+            }
+        }
+
+        // clean up tags
+        $request['tags'] = Utility::cleanTags( $request['tags'] );
+        $request['collaborators'] = preg_split("/[^a-z0-9_\-@\.']+/i", $request['collaborators'] );
+
+        // restructure requester
+        if(!isset($request['requester'])){
+            $request['requester'] = $request['requester_name']
+                ? [
+                    'name' => Utility::convertName($request['requester_name']),
+                    'email' => $request['requester_email'],
+                ]
+                : $request['requester_email'];
+
+            unset($request['requester_name']);
+            unset($request['requester_email']);
+        }
+
+        // restructure comment array
+        if(!isset($request['comment']['body'])){
+            $comment = $request['comment'];
+            $request['comment'] = [
+                'body' => $comment
+            ];
+        }
+
+        // convert custom fields format from [key:data} to [id:key,value:data] for Zendesk field referencing
+        $custom_fields = Yaml::decode($request['custom_fields']);
+        unset($request['custom_fields']);
+        $request['custom_fields'] = [];
+        if($custom_fields) {
+            foreach ($custom_fields as $key => $value) {
+                $request['custom_fields'][] = [
+                    'id' => $key,
+                    'value' => $value
+                ];
+            }
+        }
+
+        // set external_id to connect zendesk ticket with submission ID
+        $request['external_id'] = $webform_submission->id();
+
+        return $request;
     }
 
     /**

--- a/tests/src/Functional/Plugin/WebformHandler/ZendeskHandlerTest.php
+++ b/tests/src/Functional/Plugin/WebformHandler/ZendeskHandlerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\Tests\zendesk_webform\Functional\Plugin\WebformHandler;
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\Tests\webform\Functional\WebformBrowserTestBase;
+use Drupal\webform\Entity\Webform;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the Zendesk webform handler's admin UI and submission handling.
+ *
+ * No real Zendesk credentials are configured, so outbound API calls are
+ * expected to fail; these tests confirm that failure is handled gracefully
+ * (logged, no fatal error) rather than exercising real ticket delivery.
+ */
+#[Group('zendesk_webform')]
+class ZendeskHandlerTest extends WebformBrowserTestBase
+{
+
+    /**
+     * @var array
+     */
+    protected static $modules = ['webform', 'zendesk_webform'];
+
+    /**
+     * @var \Drupal\webform\WebformInterface
+     */
+    protected $webform;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->webform = Webform::create([
+            'id' => 'zendesk_test_form',
+            'title' => 'Zendesk Test Form',
+            'elements' => Yaml::encode([
+                'name' => ['#type' => 'webform_name', '#title' => 'Name'],
+                'email' => ['#type' => 'email', '#title' => 'Email'],
+                'ticket_id' => ['#type' => 'hidden', '#title' => 'Ticket ID'],
+            ]),
+        ]);
+        $this->webform->save();
+    }
+
+    public function testHandlerConfigurationForm()
+    {
+        $this->drupalLogin($this->drupalCreateUser(['administer webform']));
+
+        $this->drupalGet('/admin/structure/webform/manage/' . $this->webform->id() . '/handlers/add/zendesk');
+        $assert_session = $this->assertSession();
+        $assert_session->statusCodeEquals(200);
+
+        // The requester name/email dropdowns should be populated from the
+        // webform's own elements.
+        $assert_session->optionExists('settings[people][requester_name][select]', 'Name');
+        $assert_session->optionExists('settings[people][requester_email][select]', 'Email');
+        $assert_session->optionExists('settings[advanced][ticket_id_field][select]', 'Ticket ID');
+
+        // Save settings spread across the form's sections; this guards
+        // against a past regression where section-nested fields silently
+        // failed to save.
+        $edit = [
+            'label' => 'Zendesk',
+            'handler_id' => 'zendesk',
+            'status' => 1,
+            'settings[people][requester_name][select]' => 'name',
+            'settings[people][requester_email][select]' => 'email',
+            'settings[content][subject]' => 'New support request',
+            'settings[content][comment]' => '[webform_submission:values]',
+            'settings[content][tags]' => 'drupal webform',
+            'settings[ticket][type]' => 'question',
+            'settings[ticket][priority]' => 'normal',
+            'settings[ticket][status]' => 'new',
+            'settings[advanced][ticket_id_field][select]' => 'ticket_id',
+        ];
+        $this->submitForm($edit, 'Save');
+        $assert_session->statusCodeEquals(200);
+
+        $webform = Webform::load($this->webform->id());
+        $configuration = $webform->getHandlers()->get('zendesk')->getConfiguration();
+        $this->assertSame('name', $configuration['settings']['requester_name']);
+        $this->assertSame('email', $configuration['settings']['requester_email']);
+        $this->assertSame('New support request', $configuration['settings']['subject']);
+        $this->assertSame('ticket_id', $configuration['settings']['ticket_id_field']);
+    }
+
+    public function testHandlerSubmission()
+    {
+        $webform = $this->webform;
+        $webform->addWebformHandler(\Drupal::service('plugin.manager.webform.handler')->createInstance('zendesk', [
+            'id' => 'zendesk',
+            'handler_id' => 'zendesk',
+            'label' => 'Zendesk',
+            'status' => 1,
+            'weight' => 0,
+            'settings' => [
+                'requester_name' => 'name',
+                'requester_email' => 'email',
+                'subject' => 'New support request',
+                'comment' => '[webform_submission:values]',
+                'tags' => 'drupal webform',
+                'priority' => 'normal',
+                'status' => 'new',
+                'assignee_id' => '',
+                'type' => 'question',
+                'collaborators' => '',
+                'custom_fields' => '',
+                'ticket_id_field' => 'ticket_id',
+                'delete_after_delivery' => 0,
+            ],
+        ]));
+        $webform->save();
+
+        $sid = $this->postSubmission($webform, [
+            'name[first]' => 'Jane',
+            'name[last]' => 'Doe',
+            'email' => 'jane.doe@example.com',
+        ]);
+
+        // The submission itself must succeed, and the page must render
+        // normally, even though the (unreachable, uncredentialed) Zendesk
+        // API call behind it will fail.
+        $this->assertSession()->statusCodeEquals(200);
+        $this->assertNotNull($sid);
+        $submission = $this->loadSubmission($sid);
+        $this->assertNotNull($submission);
+    }
+}

--- a/tests/src/Kernel/Plugin/WebformHandler/ZendeskHandlerTest.php
+++ b/tests/src/Kernel/Plugin/WebformHandler/ZendeskHandlerTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Drupal\Tests\zendesk_webform\Kernel\Plugin\WebformHandler;
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\webform\Entity\Webform;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\zendesk_webform\Plugin\WebformHandler\ZendeskHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the data transformations performed by ZendeskHandler when building
+ * a Zendesk ticket request, independent of the live Zendesk API call.
+ */
+#[CoversClass(ZendeskHandler::class)]
+#[Group('zendesk_webform')]
+class ZendeskHandlerTest extends KernelTestBase
+{
+
+    /**
+     * @var array
+     */
+    protected static $modules = ['system', 'user', 'field', 'file', 'webform', 'zendesk_webform'];
+
+    /**
+     * @var \Drupal\zendesk_webform\Plugin\WebformHandler\ZendeskHandler
+     */
+    protected $handler;
+
+    /**
+     * @var \Drupal\webform\WebformInterface
+     */
+    protected $webform;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->installSchema('webform', ['webform']);
+        $this->installConfig('webform');
+        $this->installEntitySchema('webform_submission');
+        $this->installEntitySchema('user');
+        $this->installEntitySchema('file');
+
+        $this->webform = Webform::create([
+            'id' => 'zendesk_test_form',
+            'title' => 'Zendesk Test Form',
+            'elements' => Yaml::encode([
+                'name' => ['#type' => 'webform_name', '#title' => 'Name'],
+                'email' => ['#type' => 'email', '#title' => 'Email'],
+                'ticket_id' => ['#type' => 'hidden', '#title' => 'Ticket ID'],
+            ]),
+        ]);
+        $this->webform->save();
+
+        $this->handler = \Drupal::service('plugin.manager.webform.handler')->createInstance('zendesk');
+        $this->handler->setWebform($this->webform);
+    }
+
+    /**
+     * Invokes the protected buildTicketRequest() method via reflection, since
+     * it's intentionally not part of the handler's public API.
+     */
+    protected function buildTicketRequest(array $configuration, array $submission_fields, $webform_submission): array
+    {
+        $method = new \ReflectionMethod($this->handler, 'buildTicketRequest');
+        $method->setAccessible(true);
+        return $method->invoke($this->handler, $configuration, $submission_fields, $webform_submission);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $defaults = $this->handler->defaultConfiguration();
+        $this->assertArrayHasKey('requester_email', $defaults);
+        $this->assertArrayHasKey('ticket_id_field', $defaults);
+        $this->assertSame('drupal webform', $defaults['tags']);
+        $this->assertSame(0, $defaults['delete_after_delivery']);
+        $this->assertSame(array_keys($defaults), $this->handler->defaultConfigurationNames());
+    }
+
+    public function testBuildTicketRequestCleansTagsAndCollaborators()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+        $configuration['tags'] = 'Drupal, Webform!';
+        $configuration['collaborators'] = 'alice@example.com, bob@example.com';
+        $configuration['requester_email'] = 'jane.doe@example.com';
+
+        $request = $this->buildTicketRequest($configuration, ['data' => []], $submission);
+
+        $this->assertSame('drupal webform ', $request['tags']);
+        $this->assertSame(['alice@example.com', 'bob@example.com'], $request['collaborators']);
+    }
+
+    public function testBuildTicketRequestRestructuresRequesterWithName()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+        $configuration['requester_name'] = 'Jane Doe';
+        $configuration['requester_email'] = 'jane.doe@example.com';
+
+        $request = $this->buildTicketRequest($configuration, ['data' => []], $submission);
+
+        $this->assertSame([
+            'name' => 'Jane Doe',
+            'email' => 'jane.doe@example.com',
+        ], $request['requester']);
+        $this->assertArrayNotHasKey('requester_name', $request);
+        $this->assertArrayNotHasKey('requester_email', $request);
+    }
+
+    public function testBuildTicketRequestRestructuresRequesterWithoutName()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+        $configuration['requester_name'] = '';
+        $configuration['requester_email'] = 'jane.doe@example.com';
+
+        $request = $this->buildTicketRequest($configuration, ['data' => []], $submission);
+
+        $this->assertSame('jane.doe@example.com', $request['requester']);
+    }
+
+    public function testBuildTicketRequestRestructuresComment()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+        $configuration['comment'] = 'A support request.';
+
+        $request = $this->buildTicketRequest($configuration, ['data' => []], $submission);
+
+        $this->assertSame(['body' => 'A support request.'], $request['comment']);
+    }
+
+    public function testBuildTicketRequestConvertsCustomFieldsYaml()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+        $configuration['custom_fields'] = "12345678: 'foobar'\n87654321: 'baz'";
+
+        $request = $this->buildTicketRequest($configuration, ['data' => []], $submission);
+
+        $this->assertSame([
+            ['id' => 12345678, 'value' => 'foobar'],
+            ['id' => 87654321, 'value' => 'baz'],
+        ], $request['custom_fields']);
+    }
+
+    public function testBuildTicketRequestSetsExternalId()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+
+        $request = $this->buildTicketRequest($configuration, ['data' => []], $submission);
+
+        $this->assertSame($submission->id(), $request['external_id']);
+    }
+
+    public function testBuildTicketRequestPrefersSubmissionDataOverStaticValue()
+    {
+        $submission = WebformSubmission::create(['webform_id' => $this->webform->id()]);
+        $submission->save();
+
+        $configuration = $this->handler->defaultConfiguration();
+        $configuration['subject'] = 'email';
+
+        $request = $this->buildTicketRequest($configuration, ['data' => ['email' => 'jane.doe@example.com']], $submission);
+
+        $this->assertSame('jane.doe@example.com', $request['subject']);
+    }
+}

--- a/tests/src/Unit/Utils/NameTest.php
+++ b/tests/src/Unit/Utils/NameTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\Tests\zendesk_webform\Unit\Utils;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\zendesk_webform\Utils\Name;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(Name::class)]
+#[Group('zendesk_webform')]
+class NameTest extends UnitTestCase
+{
+
+    public function testProcessWithPlainString()
+    {
+        $this->assertSame('Jane', Name::process('Jane'));
+    }
+
+    public function testProcessWithFullNameArray()
+    {
+        $name = [
+            'title' => 'Dr.',
+            'first' => 'Jane',
+            'middle' => 'Q',
+            'last' => 'Doe',
+            'suffix' => 'Jr.',
+            'degree' => 'PhD',
+        ];
+        $this->assertSame('Dr. Jane Q Doe Jr. PhD', Name::process($name));
+    }
+
+    public function testProcessWithPartialNameArray()
+    {
+        $name = [
+            'first' => 'Jane',
+            'last' => 'Doe',
+        ];
+        $this->assertSame('Jane Doe', Name::process($name));
+    }
+
+    public function testProcessTrimsWhitespaceOnlyParts()
+    {
+        $name = [
+            'title' => '  ',
+            'first' => 'Jane',
+            'last' => 'Doe',
+        ];
+        $this->assertSame('Jane Doe', Name::process($name));
+    }
+}

--- a/tests/src/Unit/Utils/UtilityTest.php
+++ b/tests/src/Unit/Utils/UtilityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\Tests\zendesk_webform\Unit\Utils;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\zendesk_webform\Utils\Utility;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(Utility::class)]
+#[Group('zendesk_webform')]
+class UtilityTest extends UnitTestCase
+{
+
+    #[DataProvider('providerCheckIsNameField')]
+    public function testCheckIsNameField($type, $expected)
+    {
+        $this->assertSame($expected, Utility::checkIsNameField(['#type' => $type]));
+    }
+
+    public static function providerCheckIsNameField()
+    {
+        return [
+            'webform_name' => ['webform_name', true],
+            'textfield' => ['textfield', true],
+            'email' => ['email', false],
+            'hidden' => ['hidden', false],
+        ];
+    }
+
+    #[DataProvider('providerCheckIsEmailField')]
+    public function testCheckIsEmailField($type, $expected)
+    {
+        $this->assertSame($expected, Utility::checkIsEmailField(['#type' => $type]));
+    }
+
+    public static function providerCheckIsEmailField()
+    {
+        return [
+            'email' => ['email', true],
+            'webform_email_confirm' => ['webform_email_confirm', true],
+            'textfield' => ['textfield', false],
+            'hidden' => ['hidden', false],
+        ];
+    }
+
+    #[DataProvider('providerCheckIsHiddenField')]
+    public function testCheckIsHiddenField($type, $expected)
+    {
+        $this->assertSame($expected, Utility::checkIsHiddenField(['#type' => $type]));
+    }
+
+    public static function providerCheckIsHiddenField()
+    {
+        return [
+            'hidden' => ['hidden', true],
+            'textfield' => ['textfield', false],
+        ];
+    }
+
+    #[DataProvider('providerCheckIsGroupingField')]
+    public function testCheckIsGroupingField($type, $expected)
+    {
+        $this->assertSame($expected, Utility::checkIsGroupingField(['#type' => $type]));
+    }
+
+    public static function providerCheckIsGroupingField()
+    {
+        return [
+            'webform_section' => ['webform_section', true],
+            'textfield' => ['textfield', false],
+        ];
+    }
+
+    #[DataProvider('providerCleanTags')]
+    public function testCleanTags($input, $expected)
+    {
+        $this->assertSame($expected, Utility::cleanTags($input));
+    }
+
+    public static function providerCleanTags()
+    {
+        return [
+            'simple space separated' => ['drupal webform', 'drupal webform'],
+            'mixed case normalized to lower' => ['Drupal WEBFORM', 'drupal webform'],
+            'punctuation collapsed to spaces' => ['drupal, webform; zendesk', 'drupal webform zendesk'],
+            'trailing punctuation leaves a trailing space' => ['drupal, webform; zendesk!', 'drupal webform zendesk '],
+            'empty string' => ['', ''],
+        ];
+    }
+
+    #[DataProvider('providerConvertTags')]
+    public function testConvertTags($input, $expected)
+    {
+        $this->assertSame($expected, Utility::convertTags($input));
+    }
+
+    public static function providerConvertTags()
+    {
+        return [
+            'mixed case normalized to lower' => ['Drupal WEBFORM', 'drupal webform'],
+            'punctuation collapsed to spaces' => ['drupal, webform; zendesk', 'drupal webform zendesk'],
+        ];
+    }
+
+    public function testConvertTableWithFields()
+    {
+        $html = Utility::convertTable([12345 => 'Subject', 67890 => 'Priority']);
+        $this->assertStringContainsString('<table>', $html);
+        $this->assertStringContainsString('<td>Subject</td><td>12345</td>', $html);
+        $this->assertStringContainsString('<td>Priority</td><td>67890</td>', $html);
+    }
+
+    public function testConvertTableWithNoFields()
+    {
+        $this->assertSame('', Utility::convertTable([]));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the Zendesk ticket request-building logic out of `ZendeskHandler::postSave()` into a new `buildTicketRequest()` method, so it's testable independently of the live API call (no behavior change, verified via a live ddev submission before/after)
- Add `config/schema/zendesk_webform.schema.yml` — the module never shipped one; Drupal's strict config schema checker flagged every handler setting as unschema'd as soon as tests started saving handler configuration
- Add a PHPUnit test suite: Unit tests for the `Utility`/`Name` helpers, a Kernel test covering `buildTicketRequest()`'s data transformations, and Functional tests for the handler's admin config form (including a regression guard for the past cross-section save bug) and an end-to-end webform submission

## Test plan
- [x] `ddev phpunit web/modules/custom/zendesk_webform/tests` — 35 tests, all passing